### PR TITLE
ADD r&d part in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,21 @@
-# React + Vite
+# Rich-Text Editors Overview
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+## TipTap
+TipTap is a fully customizable rich-text editor that offers advanced functionalities, including drag-and-drop file management for efficient handling of documents and media, as well as unique node ID assignment. Note that some features require a paid version.  
+[GitHub Repository](https://github.com/ueberdosis/tiptap?tab=readme-ov-file#examples-codesandbox-and-ui-templates)
 
-Currently, two official plugins are available:
+---
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react/README.md) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+## React Jodit WYSIWYG Editor
+This package delivers a pre-built rich-text editing experience featuring a wide range of formatting options such as bold, italic, and centered text. However, it includes a watermark within the editor, which may limit its use in certain applications.  
+[GitHub Repository](https://github.com/jodit/jodit-react)
+
+---
+
+## TinyMCE
+TinyMCE generates output in HTML5 and supports the integration of elements such as lists, tables, and more. Although it provides robust editing capabilities, it includes a watermark similar to the React Jodit editor. For comprehensive documentation and further details, please refer to the [TinyMCE Docs](https://www.tiny.cloud/docs/tinymce/latest/).
+
+---
+
+## React Quill
+React Quill effectively addresses the watermark limitations found in other editors and offers the additional benefit of returning HTML code for the content entered, making it ideal for scenarios where further processing or customization is required. For more information on its advantages and design philosophy, see the [Why Quill?](https://quilljs.com/docs/why-quill) page.


### PR DESCRIPTION
## Overview

This pull request adds a new markdown document that provides a comprehensive comparison of several popular rich-text editors: **TipTap**, **React Jodit WYSIWYG Editor**, **TinyMCE**, and **React Quill**. The document is structured to highlight each editor's key features, benefits, and limitations, along with relevant documentation and repository links for further exploration.

## Changes Included

- **New Markdown File**: Added `rich-text-editors.md` containing detailed information on:
  - **TipTap**: Fully customizable with advanced functionalities like drag-and-drop file management and unique node ID assignment (paid features included).
  - **React Jodit WYSIWYG Editor**: Offers a pre-built rich-text editing experience with essential formatting tools but includes a watermark.
  - **TinyMCE**: Produces HTML5 output with support for lists, tables, etc., though it also comes with a watermark. Includes a link to the [TinyMCE Docs](https://www.tiny.cloud/docs/tinymce/latest/).
  - **React Quill**: Provides a watermark-free experience and returns HTML code for further customization. More details can be found on the [Why Quill?](https://quilljs.com/docs/why-quill) page.



